### PR TITLE
Revert ".gitignore 에 jpa buddy 플러그인의 설정 파일을 무시하도록 룰 추가"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,6 @@
 ### Querydsl
 src/main/generated
 
-### JPA Buddy
-.jpb/
-
 ### Intellij+all ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839


### PR DESCRIPTION
intellij plugin 중 jpa 작업을 편하게 해주는 jpa buddy 라는 플러그인으로 인해 자동 생성되는 설정 파일이
프로젝트에 포함되지 않도록 파일 무시 규칙을 추가함